### PR TITLE
AdamTheAnalyst: Added Config File, Added Multiple Profiles, Fixed Break Bug in Shell.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='yuuki',
-      version='0.1a2',
+      version='0.1a3',
       description='OpenC2 proxy',
       author='Joshua Brule',
       author_email='jtcbrule@gmail.com',

--- a/yuuki/dispatch.py
+++ b/yuuki/dispatch.py
@@ -11,7 +11,7 @@ class Dispatcher(object):
     TODO: fix bug - spreading the logic for one action across multiple
     modules does not work properly
     """
-    def __init__(self, *profiles):
+    def __init__(self, profiles):
         self.modules = collections.deque()
         for module in profiles:
             self.modules.appendleft(imp.load_source('profile', module))

--- a/yuuki/shell.py
+++ b/yuuki/shell.py
@@ -43,6 +43,7 @@ def main():
             break
         except KeyboardInterrupt:
             print "^C"
+            break
         except Exception as e:
             print "{}: {}".format(e.__class__.__name__, str(e))
 

--- a/yuuki/shell.py
+++ b/yuuki/shell.py
@@ -43,7 +43,6 @@ def main():
             break
         except KeyboardInterrupt:
             print "^C"
-            break
         except Exception as e:
             print "{}: {}".format(e.__class__.__name__, str(e))
 

--- a/yuuki/yuuki.conf
+++ b/yuuki/yuuki.conf
@@ -1,0 +1,18 @@
+#_____.___.            __   .__ 
+#\__  |   |__ __ __ __|  | _|__|
+# /   |   |  |  \  |  \  |/ /  |
+# \____   |  |  /  |  /    <|  |
+# / ______|____/|____/|__|_ \__|
+# \/                       \/   
+
+[server]
+host = 0.0.0.0
+port = 9001
+
+[profiles]
+# profile_name = profile_path
+simple_profile = ./examples/simple_profile.py
+simple_notify = ./examples/simple_notify.py
+
+[profile_settins]
+custom_setting = "1.2.3.4"


### PR DESCRIPTION
I have added the following which should enable me to get up and running with profile creation:
## Config File

Found in yuuki.conf, allows users to define the location of profiles and network settings without passing them as args. This config then gets loaded into the flask app context so can be accessed by profiles if necessary in the future (IP's of routers etc) using "from flask import current_app as app".

I have stored this in the config dict app.config["yuuki"] rather than using flask's traditional "app.config.from_envvar" to load it into Flask's default config. This means that the user can't define profile names that would interfere with Flask's operation. If you don't like this approach and want to use Flask's inbuilt method then I am happy to change it.
## Break In Shell.py

Just to catch ^C's, it wasn't exiting before.
## Multiple Profile Loading

Profiles are now defined in the config file under the "[profiles]" section, they are then loaded in to a list which gets passed to the Dispatcher's constructor and loaded in the same way.
 master.

I am happy to change anything you don't see as working, just let me know. After this I should be able to continue as we talked about, building more profiles for vendor technologies without tampering with your core functionality. 

Cheers

Adam
